### PR TITLE
Bump version of html-proofer used so nokogiri can be upgraded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :jekyll_plugins do
 end
 
 group :test do
-  gem 'html-proofer', '~> 3.4'
+  gem 'html-proofer', '~> 3.15'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,24 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.0)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    colorize (0.8.1)
     concurrent-ruby (1.1.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
-    ethon (0.11.0)
+    ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
     ffi (1.11.2)
     forwardable-extended (2.6.0)
-    html-proofer (3.8.0)
-      activesupport (>= 4.2, < 6.0)
+    html-proofer (3.15.0)
       addressable (~> 2.3)
-      colorize (~> 0.8)
-      mercenary (~> 0.3.2)
-      nokogiri (~> 1.8.1)
+      mercenary (~> 0.3)
+      nokogumbo (~> 2.0)
       parallel (~> 1.3)
+      rainbow (~> 3.0)
       typhoeus (~> 1.3)
       yell (~> 2.0)
     http_parser.rb (0.6.0)
@@ -68,14 +61,16 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.3.0)
-    minitest (5.11.3)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
-    parallel (1.12.1)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.7)
+      mini_portile2 (~> 2.4.0)
+    nokogumbo (2.0.2)
+      nokogiri (~> 1.8, >= 1.8.4)
+    parallel (1.19.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.1)
+    rainbow (3.0.0)
     rake (11.3.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -88,18 +83,15 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    thread_safe (0.3.6)
-    typhoeus (1.3.0)
+    typhoeus (1.3.1)
       ethon (>= 0.9.0)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
-    yell (2.0.7)
+    yell (2.2.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  html-proofer (~> 3.4)
+  html-proofer (~> 3.15)
   jekyll (~> 3.7.4)
   jekyll-feed (~> 0.6)
   jekyll-paginate (~> 1.1.0)
@@ -112,4 +104,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
Addresses CVE-2019-5477