### PR TITLE
Fix build failing due to https://blog.algolia.com/may-30-ssl-incident/

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,7 @@ task :test => [:build] do
   typhoeus_configuration = {
     :connecttimeout => 300,
     :timeout => 300,
+    :ssl_verifypeer => false,
   }
   options = {
     :allow_hash_href => true,


### PR DESCRIPTION
This PR fixes this build failure:

```
Checking 113 external links...
Ran on 59 files!


- _site/2010/12/12/o-circuit-tree-o-circuit-tree.html
  *  External link http://stouffer.house.upenn.edu/ failed: 302 Peer certificate cannot be authenticated with given CA certificates
- _site/2018/05/03/vr-proposal.html
  *  External link https://devpost.com/software/paint-mate-ar failed: response code 0 means something's wrong.
             It's possible libcurl couldn't connect to the server or perhaps the request timed out.
             Sometimes, making too many requests at once also breaks things.
             Either way, the return message (if any) from the server is: Peer certificate cannot be authenticated with given CA certificates
HTML-Proofer found 2 failures!
```

E.g. https://travis-ci.org/github/kevincon/kevintechnology.com/builds/695384720

I wasn't able to figure out how to properly fix this, but I'm not too concerned about checking certificates; I just want to know if links are broken or not on my website.