### PR TITLE
Change Heiko's website to use .com TLD instead of .net to fix CI build

### DIFF
--- a/_posts/2017-03-01-porting-game-boy-emulators-to-the-pebble-time.md
+++ b/_posts/2017-03-01-porting-game-boy-emulators-to-the-pebble-time.md
@@ -52,7 +52,7 @@ Here are some pictures of Pokemon Red running on the Pebble Time:
 
 ## Version Two: SDK App
 
-In August 2015 I worked with [Heiko Behrens](https://heikobehrens.net/) on another version of the Pebble Game Boy emulator. We ported an emulator called [PlutoBoy](https://github.com/RossMeikleham/PlutoBoy) using the public Pebble SDK so it could be side-loaded as a regular Pebble app. This was a fun challenge because:
+In August 2015 I worked with [Heiko Behrens](https://heikobehrens.com/) on another version of the Pebble Game Boy emulator. We ported an emulator called [PlutoBoy](https://github.com/RossMeikleham/PlutoBoy) using the public Pebble SDK so it could be side-loaded as a regular Pebble app. This was a fun challenge because:
 
 1. SDK apps have access to far less RAM than a built-in firmware app
 2. SDK apps only receive 256 KB of resource storage for ROMs (so unfortunately Pokemon is not an option)


### PR DESCRIPTION
CI is failing due to seeing an SSL warning when trying to access heikobehrens.net: https://github.com/kevincon/kevintechnology.com/runs/5802610736?check_suite_focus=true

The issue appears to be that the SSL certificate for the site is only setup for heikobehrens.com and not also heikobehrens.net:

![image](https://user-images.githubusercontent.com/817753/161448129-35e4b093-b9c2-4f25-b65f-f6c2eabbc162.png)

To fix the CI build I'm just changing the link on the site to use .com instead of .net.