### PR TITLE
Fix broken Intel and PennApps links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ description: >- # this means to ignore newlines until the next key
   My name is Kevin Conley, and I am a versatile software engineer
   who loves improving developer productivity and infrastructure. \\
    \\
-  Previously I worked on firmware for [Intel Optane SSDs](https://www.intel.com/content/www/us/en/products/memory-storage/solid-state-drives.html), the
+  Previously I worked on firmware for [Intel Optane Client SSDs](https://en.wikipedia.org/wiki/3D_XPoint), the
   [Intel Vaunt smart glasses](https://www.theverge.com/2018/2/5/16966530/intel-vaunt-smart-glasses-announced-ar-video), and several smart watches at [Pebble](https://en.wikipedia.org/wiki/Pebble_(watch)).
 copyright: © 2020 Kevin Conley
 baseurl: "" # the subpath of your site, e.g. /blog

--- a/_posts/2013-09-15-preventing-cheating-at-hackathons.md
+++ b/_posts/2013-09-15-preventing-cheating-at-hackathons.md
@@ -28,7 +28,7 @@ The idea of cheating at hackathons isn’t new, and [others](https://news.ycombi
 
 I’ll concede that talking about cheating at hackathons isn’t much fun. Despite the competitive atmosphere, my favorite aspect of hackathons is the sense of community I feel there when participants share their passion for tech and help each other learn how to use new programming languages and technologies.
 
-Nevertheless, the stakes are becoming too high to ignore the notion of cheating at hackathons. This past weekend at the [PennApps](http://2013f.pennapps.com/) hackathon at the University of Pennsylvania, hackathon participants competed for over $27,000 in prizes. The [MHacks](http://mhacks.org/) hackathon at the University of Michigan, to be held next weekend, is offering over $30,000 in prizes.
+Nevertheless, the stakes are becoming too high to ignore the notion of cheating at hackathons. This past weekend at the [PennApps](https://web.archive.org/web/20140330215345/http://2013f.pennapps.com/) hackathon at the University of Pennsylvania, hackathon participants competed for over $27,000 in prizes. The [MHacks](http://mhacks.org/) hackathon at the University of Michigan, to be held next weekend, is offering over $30,000 in prizes.
 
 ### Types of Cheating
 

--- a/uwave/howitworks.html
+++ b/uwave/howitworks.html
@@ -218,7 +218,8 @@
 					<a target="new" href="https://www.benshyong.com/">Ben Shyong</a>,
 					<a target="new" href="http://vsampath.com">Varun Sampath</a>,
 					<a target="new" href="https://www.linkedin.com/in/ted-zhang-a854b129/">Teddy Zhang</a> for
-					<a target="new" href="https://www.pennapps.com">PennApps</a>.
+					<a target="new"
+						href="https://web.archive.org/web/20140612074401/http://2011f.pennapps.com/blog/2011/9/18/congratulations-to-the-winners.html">PennApps</a>.
 			</center>
 		</footer>
 	</div>

--- a/uwave/index.html
+++ b/uwave/index.html
@@ -62,7 +62,8 @@
 					</p>
 					<p>P.S.
 						<a target="new"
-							href="http://2011f.pennapps.com/blog/2011/9/18/congratulations-to-the-winners.html">We won
+							href="https://web.archive.org/web/20140612074401/http://2011f.pennapps.com/blog/2011/9/18/congratulations-to-the-winners.html">We
+							won
 							first place at PennApps!</a>
 					</p>
 					<p>Contact us at
@@ -102,7 +103,8 @@
 					<a target="new" href="https://www.benshyong.com/">Ben Shyong</a>,
 					<a target="new" href="http://vsampath.com">Varun Sampath</a>,
 					<a target="new" href="https://www.linkedin.com/in/ted-zhang-a854b129/">Teddy Zhang</a> for
-					<a target="new" href="https://www.pennapps.com">PennApps</a>.
+					<a target="new"
+						href="https://web.archive.org/web/20140612074401/http://2011f.pennapps.com/blog/2011/9/18/congratulations-to-the-winners.html">PennApps</a>.
 			</center>
 		</footer>
 


### PR DESCRIPTION
Intel discontinued Optane SSDs 😢 : https://www.tomshardware.com/news/intel-kills-optane-memory-business-for-good

Not sure what's going on with the PennApps website: https://twitter.com/kevindcon/status/1574459918152712192